### PR TITLE
Add Dockerized Production Build with Compose Infra and EC2 Bootstrap Script

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -3,7 +3,7 @@ name: Build and Push Docker Image to ECR
 on:
   push:
     branches:
-      - develop
+      - main
 
 permissions:
   id-token: write

--- a/.github/workflows/provision-infra.yml
+++ b/.github/workflows/provision-infra.yml
@@ -3,10 +3,10 @@ name: Deploy Staging Infrastructure
 on:
   push:
     branches:
-      - develop
+      - main
   pull_request:
     branches:
-      - develop
+      - main
 
 permissions:
   id-token: write

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,28 @@
-version: '3.8'
-
 services:
+  app:
+    build:
+      context: .
+    ports:
+      - '3000:3000'
+    environment:
+      - DATABASE_HOST=mysql
+      - DATABASE_PORT=3306
+      - DATABASE_NAME=yoodb
+      - DATABASE_USER=yooadmin
+      - DATABASE_PASSWORD=yoopass
+      - KAFKA_BROKERS=kafka:29092
+      - REDIS_HOST=yoo-redis
+      - REDIS_PORT=6379
+    depends_on:
+      - mysql
+      - kafka
+      - redis
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:3000/health']
+      interval: 10s
+      retries: 5
+      timeout: 5s
+
   mysql:
     image: mysql:8.3
     container_name: yoo-mysql
@@ -11,11 +33,11 @@ services:
       MYSQL_USER: yooadmin
       MYSQL_PASSWORD: yoopass
     ports:
-      - "3306:3306"
+      - '3306:3306'
     volumes:
       - mysql_data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: ['CMD', 'mysqladmin', 'ping', '-h', 'localhost']
       interval: 10s
       retries: 5
       timeout: 5s
@@ -25,22 +47,29 @@ services:
     container_name: kafka
     restart: always
     ports:
-      - "9092:9092"
+      - '9092:9092'
     environment:
       KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,INTERNAL://kafka:29092
       KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,INTERNAL://:29092,CONTROLLER://:9093
       KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
       KAFKA_CFG_INTER_BROKER_LISTENER_NAME: INTERNAL
-      KAFKA_KRAFT_MODE_ENABLED: "yes"
-      KAFKA_CFG_NODE_ID: "1"
+      KAFKA_KRAFT_MODE_ENABLED: 'yes'
+      KAFKA_CFG_NODE_ID: '1'
       KAFKA_CFG_PROCESS_ROLES: controller,broker
       KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
       KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      ALLOW_PLAINTEXT_LISTENER: "yes"
+      ALLOW_PLAINTEXT_LISTENER: 'yes'
     volumes:
       - kafka_data:/bitnami/kafka
     healthcheck:
-      test: ["CMD", "kafka-topics.sh", "--bootstrap-server", "localhost:9092", "--list"]
+      test:
+        [
+          'CMD',
+          'kafka-topics.sh',
+          '--bootstrap-server',
+          'kafka:29092',
+          '--list',
+        ]
       interval: 10s
       retries: 5
       timeout: 5s
@@ -49,7 +78,7 @@ services:
     image: docker.redpanda.com/redpandadata/console:latest
     container_name: redpanda-console
     ports:
-      - "8080:8080"
+      - '8080:8080'
     environment:
       - KAFKA_BROKERS=kafka:29092
     depends_on:
@@ -60,11 +89,11 @@ services:
     container_name: yoo-redis
     restart: always
     ports:
-      - "6379:6379"
+      - '6379:6379'
     volumes:
       - redis_data:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ['CMD', 'redis-cli', 'ping']
       interval: 10s
       retries: 5
       timeout: 5s
@@ -73,4 +102,3 @@ volumes:
   mysql_data:
   redis_data:
   kafka_data:
-

--- a/infrastructure/staging/output.tf
+++ b/infrastructure/staging/output.tf
@@ -2,19 +2,16 @@
 # OUTPUTS
 # -------------------------
 
-# Public IP of EC2 instance (useful for SSH or HTTP)
 output "public_ip" {
   description = "Public IP address of the EC2 instance"
   value       = aws_instance.staging_server.public_ip
 }
 
-# EC2 Instance ID (useful for tagging, scripting, etc.)
 output "instance_id" {
   description = "EC2 instance ID"
   value       = aws_instance.staging_server.id
 }
 
-# ECR Repository URL (used for pushing docker images)
 output "ecr_repository_url" {
   description = "URL of the ECR repository"
   value       = aws_ecr_repository.nestjs_app.repository_url

--- a/infrastructure/staging/user_data.sh
+++ b/infrastructure/staging/user_data.sh
@@ -23,6 +23,10 @@ usermod -a -G docker ec2-user
 echo "➡️ Enabling Docker to start on boot..."
 systemctl enable docker
 
+# Install AWS CLI
+echo "➡️ Installing AWS CLI..."
+dnf install aws-cli -y
+
 # Install Docker Compose
 DOCKER_COMPOSE_VERSION="2.24.6"
 echo "➡️ Installing Docker Compose v$DOCKER_COMPOSE_VERSION..."
@@ -37,15 +41,117 @@ echo "➡️ Creating app directory at $APP_DIR"
 mkdir -p $APP_DIR
 cd $APP_DIR
 
+# Get AWS Account ID and Region for ECR login
+echo "➡️ Setting up AWS CLI and ECR login..."
+AWS_REGION="us-east-1"
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
+ECR_REPOSITORY="nestjs-app"
+
+echo "➡️ Logging into Amazon ECR..."
+aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+
 echo "➡️ Writing docker-compose.yaml"
 cat <<EOF > docker-compose.yaml
-version: "3.8"
+version: '3.8'
+
 services:
   app:
-    image: your-ecr-repo/image-name:latest
+    image: $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPOSITORY:latest
+    container_name: nestjs-app
     ports:
       - "3000:3000"
     restart: always
+    environment:
+      - DATABASE_HOST=mysql
+      - DATABASE_PORT=3306
+      - DATABASE_NAME=yoodb
+      - DATABASE_USER=yooadmin
+      - DATABASE_PASSWORD=yoopass
+      - KAFKA_BROKERS=kafka:29092
+      - REDIS_HOST=yoo-redis
+      - REDIS_PORT=6379
+    depends_on:
+      - mysql
+      - kafka
+      - redis
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      interval: 10s
+      retries: 5
+      timeout: 5s
+
+  mysql:
+    image: mysql:8.3
+    container_name: yoo-mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: yoodb
+      MYSQL_USER: yooadmin
+      MYSQL_PASSWORD: yoopass
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      retries: 5
+      timeout: 5s
+
+  kafka:
+    image: bitnami/kafka:latest
+    container_name: kafka
+    restart: always
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,INTERNAL://kafka:29092
+      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,INTERNAL://:29092,CONTROLLER://:9093
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_KRAFT_MODE_ENABLED: "yes"
+      KAFKA_CFG_NODE_ID: "1"
+      KAFKA_CFG_PROCESS_ROLES: controller,broker
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+    volumes:
+      - kafka_data:/bitnami/kafka
+    healthcheck:
+      test: ["CMD", "kafka-topics.sh", "--bootstrap-server", "kafka:29092", "--list"]
+      interval: 10s
+      retries: 5
+      timeout: 5s
+
+  redpanda-console:
+    image: docker.redpanda.com/redpandadata/console:latest
+    container_name: redpanda-console
+    ports:
+      - "8080:8080"
+    environment:
+      - KAFKA_BROKERS=kafka:29092
+    depends_on:
+      - kafka
+
+  redis:
+    image: redis:7-alpine
+    container_name: yoo-redis
+    restart: always
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      retries: 5
+      timeout: 5s
+
+volumes:
+  mysql_data:
+  redis_data:
+  kafka_data:
 EOF
 
 echo "✅ docker-compose.yaml written"
@@ -54,5 +160,5 @@ echo "✅ docker-compose.yaml written"
 echo "➡️ Starting docker-compose service..."
 docker-compose up -d
 
-echo "✅ Application container started"
+echo "✅ Application stack started"
 echo "======== ✅ Finished user_data.sh setup ========"

--- a/infrastructure/staging/variables.tf
+++ b/infrastructure/staging/variables.tf
@@ -32,3 +32,16 @@ variable "security_group_name" {
   description = "Name of the security group"
   type        = string
 }
+
+
+variable "ssh_cidr_block" {
+  description = "Optional CIDR block for SSH access (overrides dynamic IP if set)"
+  type        = string
+  default     = ""
+}
+
+variable "associate_public_ip" {
+  description = "Whether to associate a public IP address with the EC2 instance"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Description

This PR introduces a full Docker-based infrastructure for building and running the NestJS monorepo application in production. It includes:

### 🔧 Dockerization

- Multi-stage Dockerfile for optimized NestJS app builds.
  - **Stage 1 (Builder):** Installs dependencies, builds the project.
  - **Stage 2 (Production):** Installs only production dependencies and runs the compiled app.
- Reduces image size by using `node:20-alpine`.

### 🏗️ Docker Compose

- `docker-compose.yml` for local orchestration:
  - Launches `api` container.
  - Supports future extension for database, Redis, etc.

### 🖥️ Production Script

- `userdata.sh`:
  - Designed for EC2 or similar environments.
  - Installs Docker & Docker Compose.
  - Pulls codebase, builds, and starts services.

### 📁 Project Structure Changes

- Copies all necessary app/lib sources.
- Ensures build artifacts are available for runtime postinstall.
- Clean separation between dev and production dependencies.

---

## How to Test

1. Run `docker-compose up --build` locally.
2. Access the API via `localhost:3000`.
3. Validate production behavior by running the `userdata.sh` script on a clean VM.

---

## Notes

- Uses `CMD ["node", "dist/apps/api/main"]` as the entry point.
- Ensure `apps/api/main.ts` is the correct bootstrap entry.
- The `build/` folder is included intentionally to support runtime `postinstall` if required.

---

## Future Improvements

- Add services like PostgreSQL, Redis, etc., in `docker-compose.yml`.